### PR TITLE
ch03 -  Disable Argo CD TLS and offload TLS termination to the ingress controller for secure external access

### DIFF
--- a/ch03/argocd-cmd-params-cm.yml
+++ b/ch03/argocd-cmd-params-cm.yml
@@ -1,0 +1,10 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: argocd-cmd-params-cm
+  namespace: argocd
+  labels:
+    app.kubernetes.io/name: argocd-cmd-params-cm
+    app.kubernetes.io/part-of: argocd
+data:
+  server.insecure: "true"   # Run server without TLS


### PR DESCRIPTION
- Disable Argo CD TLS (runs Argo CD in insecure mode internally).
- Offload TLS termination to the ingress controller for secure external access.